### PR TITLE
fix link

### DIFF
--- a/Week_04.ipynb
+++ b/Week_04.ipynb
@@ -100,7 +100,7 @@
     "## 3. Theory and examples of least-squares interpolation using linear algebra\n",
     "* a flexible and general presentation of least squares\n",
     "* and how one solves (quite flexibly) for functions that interpolate a wide variety of data\n",
-    "* see [interpolation example](https://github.com/fherwig/physmath248_pilot/blob/master/stats/least-squares.sketch.ipynb)\n",
+    "* see [interpolation example](./examples/least-squares.sketch.ipynb)\n",
     "* moments of distributions. \n",
     "\n",
     "***Homework: ***\n",


### PR DESCRIPTION
Ryen, I have
changed 
* see [interpolation example](https://github.com/fherwig/physmath248_pilot/blob/master/stats/least-squares.sketch.ipynb)
to
* see [interpolation example](.examples/least-squares.sketch.ipynb)

I am also no favouring relative links to notebooks inside the repo which means following those links does not point to github, is faster and does not require internet. Unless you object I would clean-up links in this fashion as I come across them.